### PR TITLE
Update to Scala 2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jdk:
 
 matrix:
   include:
-  - scala: 2.12.0-RC2
+  - scala: 2.12.0
     jdk: oraclejdk8
 
 script:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@ https://gitter.im/typelevel/sbt-catalysts](https://badges.gitter.im/Join%20Chat.
 
 Catalysts is an intentionally small library of small moduless to help build and test platform independent Scala projects with SBT.
 
-This interim version adds 2.12 support. It locally builds scoverage libraries, so to build his PR locally:
-
-```bash
-scripts/publishLocalScoverage.sh
-scripts/publishLocalSbtScoverage.sh
-sbt +clean coverageOn +test +clean coverageOff +test
-```
-
 ### Maintainers
 
 The current maintainers (people who can merge pull requests) are:

--- a/build.sbt
+++ b/build.sbt
@@ -209,7 +209,7 @@ lazy val scoverageSettings = sharedScoverageSettings(60) ++ Seq(
 def localSharedBuildSettings(gh: GitHubSettings, v: Versions) = Seq(
     organization := gh.publishOrg,
     scalaVersion := v.vers("scalac"),
-    crossScalaVersions := Seq(v.vers("scalac_2.10"), "2.12.0-RC2", scalaVersion.value)
+    crossScalaVersions := Seq(v.vers("scalac_2.10"), "2.12.0", scalaVersion.value)
   )
 
 val cmdlineProfile = sys.props.getOrElse("sbt.profile", default = "")

--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,8 @@ lazy val disciplineDependencies = Seq(addLibs(vAll, "discipline", "scalacheck" )
 lazy val publishSettings = sharedPublishSettings(gh, devs) ++ credentialSettings ++ sharedReleaseProcess
 
 lazy val scoverageSettings = sharedScoverageSettings(60) ++ Seq(
-  coverageExcludedPackages := "catalysts\\.Platform"
+  coverageExcludedPackages := "catalysts\\.Platform",
+  coverageScalacPluginVersion := "1.3.0"
 )
 
  /** Common coverage settings, with minimum coverage defaulting to 80.*/

--- a/project/CatalystsDeps.scala
+++ b/project/CatalystsDeps.scala
@@ -11,10 +11,10 @@ object Dependencies {
   // Package -> version
   val versions = Map[String, String](
    // "macro-compat"   -> "1.0.44"
-    "discipline"     -> "0.7.1",
-    "scalacheck"     -> "1.13.3",
+    "discipline"     -> "0.7.2",
+    "scalacheck"     -> "1.13.4",
     "scalatest"      -> "3.0.0",
-    "specs2"         -> "3.8.5.1"
+    "specs2"         -> "3.8.6"
   )
 
   // library definitions and links to their versions

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13-RC3
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
+resolvers += Resolver.sonatypeRepo("releases")
+
 addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.12")
 
 // override for now until sbt-catalysts is updated
 addSbtPlugin("org.scala-js"        %  "sbt-scalajs"            % "0.6.13")
-addSbtPlugin("org.scoverage"       %  "sbt-scoverage"          % "1.5.0-RC2")
+addSbtPlugin("org.scoverage"       %  "sbt-scoverage"          % "1.5.0")
 addSbtPlugin("org.tpolecat"        %  "tut-plugin"             % "0.4.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.1.12")
 // override for now until sbt-catalysts is updated
 addSbtPlugin("org.scala-js"        %  "sbt-scalajs"            % "0.6.13")
 addSbtPlugin("org.scoverage"       %  "sbt-scoverage"          % "1.5.0-RC2")
-addSbtPlugin("org.tpolecat"        %  "tut-plugin"             % "0.4.5")
+addSbtPlugin("org.tpolecat"        %  "tut-plugin"             % "0.4.6")


### PR DESCRIPTION
Okay, the Scoverage compiler plugin, runtime, and SBT plugin are all updated. The SBT plugin hasn't been synced to Maven Central yet (even though it was published yesterday), but adding the Sonatype releases resolver makes this work until it gets synced. Given that this is all build stuff, I don't think that's unreasonable.

There is still ~~two~~ one thing that seems to be broken in Scoverage: in sbt-scoverage 1.5.0, the default Scoverage compiler plugin version is [wrong](https://github.com/scoverage/sbt-scoverage/pull/201) (it's the 1.3.0 snapshot, not release). This is easy enough to work around with a bit of explicit configuration.

~~The bigger problem is that the Scoverage runtime isn't published for Scala.js on Scala 2.11 (on either Maven Central or Sonatype releases). As soon as that's done this PR should be ready for review.~~

~~We're still waiting on [Scoverage](https://github.com/scoverage/scalac-scoverage-plugin/issues/192), but these changes at least allow us to publish Catalysts locally and test the Cats 2.12.0 build (just not with Scoverage).~~