### PR TITLE
updated to sbt-catalyst and thus scala 2.13.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
+import sbtcrossproject.CrossProject
 import org.typelevel.{Dependencies => typelevel}
 import org.typelevel.catalysts.{Dependencies => catalysts}
-import org.scalajs.sbtplugin.cross.{ CrossProject, CrossType }
+import sbtcrossproject.CrossPlugin.autoImport.CrossType
 
 /**
  * These aliases serialise the build for the benefit of Travis-CI, also useful for pre-PR testing.

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ val addins = typelevel.scalacPlugins ++ catalysts.scalacPlugins
 val vAll = Versions(vers, libs, addins)
 
 // 2.13.0-M3 workaround
-val scalatest_2_13 = "3.0.6-SNAP1"
-val specs2_2_13 = "4.3.0"
+val scalatest_2_13 = "3.0.6-SNAP4"
+val specs2_2_13 = "4.3.5"
 /**
  * catalysts - This is the root project that aggregates the catalystsJVM and catalystsJS sub projects
  */
@@ -158,7 +158,10 @@ lazy val specliteJVM = specliteM.jvm
 lazy val specliteJS  = specliteM.js
 lazy val specliteM   =  module("speclite", CrossType.Pure)
   .dependsOn(platformM, testkitM % "compile; test -> test", specbaseM % "compile; test -> test")
-  .settings(testFrameworks := Seq(new TestFramework("catalysts.speclite.SpecLiteFramework")))
+  .settings(
+    testFrameworks := Seq(new TestFramework("catalysts.speclite.SpecLiteFramework")),
+    scalacOptions -= "-Xfatal-warnings" //temp solution for some deprecations warnings
+  )
   .jvmSettings(libraryDependencies += "org.scala-sbt" %  "test-interface" % "1.0")
   .jvmSettings(libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion)
   .jsSettings( libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion)

--- a/project/CatalystsDeps.scala
+++ b/project/CatalystsDeps.scala
@@ -11,8 +11,8 @@ object Dependencies {
   // Package -> version
   val versions = Map[String, String](
    // "macro-compat"   -> "1.0.44"
-  // "discipline"     -> "0.8",
-  "scalacheck"     -> "1.14.0",
+   "discipline"     -> "0.10.0",
+   "scalacheck"     -> "1.14.0",
    "scalatest"      -> "3.0.6-SNAP4",
    "specs2"         -> "4.3.0"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,5 @@
 //resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.9.2")
+addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.9.3")
 
-// override for now until sbt-catalysts is updated
-//addSbtPlugin("org.scala-js"        %  "sbt-scalajs"            % "0.6.19")
-//addSbtPlugin("org.scoverage"       %  "sbt-scoverage"          % "1.5.0")
-addSbtPlugin("org.tpolecat"        %  "tut-plugin"             % "0.6.4")
+addSbtPlugin("org.tpolecat"        %  "tut-plugin"             % "0.6.9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 //resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.8.9")
+addSbtPlugin("org.typelevel" % "sbt-catalysts" % "0.9.2")
 
 // override for now until sbt-catalysts is updated
 //addSbtPlugin("org.scala-js"        %  "sbt-scalajs"            % "0.6.19")

--- a/speclite/src/main/scala/speclite/Pretty.scala
+++ b/speclite/src/main/scala/speclite/Pretty.scala
@@ -3,7 +3,7 @@
 package catalysts
 package speclite
 
-import scala.language.{implicitConversions, reflectiveCalls}
+import scala.language.{reflectiveCalls}
 import Prop.Arg
 
 sealed trait Pretty extends Serializable {


### PR DESCRIPTION
There is still some work to be done. 
Namely an outdated scalac flag and missing discipline, right now it fails on 2.13-M5 with

>[info]   Compilation completed in 12.485s.
[error] bad option: '-Ywarn-unused-import'
[error] bad option: '-Ywarn-unused-import'
[error] coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[error]     org.typelevel:discipline_2.13.0-M5:0.9.0:
[error]         not found:

I am not sure when I will have time to get back to this, if anyone is interested please feel free to take over. 

cc @erikerlandson