### PR TITLE
Adopt the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+People are expected to follow the
+[Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
+discussing Catalysts on the Github page, Gitter channel, or other
+venues.
+
+We hope that our community will be respectful, helpful, and kind. If
+you find yourself embroiled in a situation that becomes heated, or
+that fails to live up to our expectations, you should disengage and
+contact one of the [project maintainers](README.md#maintainers) in private. We
+hope to avoid letting minor aggressions and misunderstandings escalate
+into larger problems.
+
+If you are being harassed, please contact one of [us](README.md#maintainers)
+immediately so that we can support you.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ feature, or have a question about the code. Pull requests are also
 gladly accepted.
 
 People are expected to follow the
-[Typelevel Code of Conduct](http://typelevel.org/conduct.html) when
+[Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
 discussing Catalysts on the Github page, Gitter channel, or other
 venues.
 


### PR DESCRIPTION
Typelevel is about to announce that it is moving to the Scala Code of Conduct for all participating projects. The Scala Code of Conduct was by developed by the Scala Center with input from Typelevel and improves on the Typelevel code of conduct in a number of ways and can be thought of as the "Typelevel code of conduct v. 2.0". We want people participating in projects and activities right across the Scala ecosystem to be able to expect a uniform standard of good behavior, and coordinating on a shared code of conduct is an important step in that direction.